### PR TITLE
Removed ext-mcrypt recommendation, fixes #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ phpseclib - [PHP Secure Communications Library](https://phpseclib.com/)
 
 puzi-laravel - [Laravel wrapper for proficient UZI pass reader](https://github.com/minvws/pUZI-laravel) for Laravel 6, 7 and 8.
 
+## Alternatives
+
+dotnet - [UZI Card Authentication Server](https://github.com/hiddehs/UZI-Card-Authentication)
+
 ## Contributing
 
 1. Fork the Project

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,6 @@
   },
   "suggest": {
     "ext-openssl": "Install the OpenSSL extension in order to speed up a wide variety of cryptographic operations.",
-    "ext-mcrypt": "Install the Mcrypt extension in order to speed up a few other cryptographic operations.",
     "ext-gmp": "Install the GMP (GNU Multiple Precision) extension in order to speed up arbitrary precision integer arithmetic operations."
   }
 }


### PR DESCRIPTION
As noted by @stiiin  `ext/mcrypt` has been deprecated since PHP 7.1 https://www.php.net/manual/en/migration71.deprecated.php

As a bonus added a link to a .NET alternative.